### PR TITLE
Search reacts to Enter now

### DIFF
--- a/Public/HTML/index.html
+++ b/Public/HTML/index.html
@@ -87,7 +87,7 @@
 
         <div id="devsSelection">
             <h2 class="devItem">List of devices</h2>
-            <input type="search" id="searchDev" onblur=filterByCriteria()>
+            <input type="search" id="searchDev">
             <small title="Drive search is tied to selected filters. For example: if Opal 2.02 is selected, then drives with Pyrite won't be selected and you need to tick them explicitly.">&#9432;</small>
             <div id="devList"></div>
             <div name="addDevPrompt" style="display: none;" class="authorized">

--- a/Public/JS/index.js
+++ b/Public/JS/index.js
@@ -490,6 +490,10 @@ function renderCBoxes(){
                 }
             }
         }
+        // Clear search text input if user explicitly (de)selected a device
+        checkbox.onclick = () => {
+            document.getElementById("searchDev").value = ""
+        }
     }
     // Filtration based on Feature Sets
     let fSetBoxes = document.getElementsByClassName("staticFsetCBox");
@@ -1053,6 +1057,10 @@ document.body.addEventListener("click", (event) => {
             element.style.display = "none"
         }
     }
+})
+
+document.getElementById("searchDev").addEventListener("keyup", (event) => {
+    if(event.code == 'Enter') filterByCriteria()
 })
 
 document.getElementById("filterButton").addEventListener("click", (event) => {


### PR DESCRIPTION
Fixes #4 by changing the event triggering the filter to Enter key + clicking on a device's checkbox clears the search box