### PR TITLE
metadata file upload size and type checks added + fixed URL in metadata

### DIFF
--- a/Public/HTML/details.html
+++ b/Public/HTML/details.html
@@ -101,7 +101,7 @@
                 <p>URL</p>
                 <input type="text" name="" id="mdUrl" placeholder="www.storage.com/rngtesting.json"><br>
                 <p>File</p>
-                <input type="file" id="mdFile"><br>
+                <input type="file" id="mdFile"><small id="fileHint">&#9432;</small><br>
                 <button class="submitButton" type="submit" onclick=saveMetadata()>Upload</button>
             </div>
         </div>


### PR DESCRIPTION
Fixes #5 

Set metadata file upload limit to 20MB and added restrictions to accepted filetypes. A hint was added to file upload button to inform the user about said restrictions.

Also added a fix to protocols being used in metadata URLs. Bug here was being caused by a workaround of the situation when you don't specify a protocol in a link being put into href property. This would result in a relative link. Therefore a check for protocol is added and HTTPS is prepended if none is found.